### PR TITLE
Add ATX awareness to the libretro core code.

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -363,7 +363,7 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
    info->library_name     = "Atari800";
    info->library_version  = "3.1.0" GIT_VERSION;
-   info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip";
+   info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx";
    info->need_fullpath    = true;
    info->block_extract = false;
 


### PR DESCRIPTION
The core atari800 code has had support for ATX disk images for quite some time. ATX is a disk format created by ijor of the Atari community that encodes a hybrid of sector data and additional flux transition data that's required to replicate copy protection schemes. 