### PR TITLE
Add core options to atari800.

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -33,6 +33,26 @@ extern char RPATH[512];
 extern char RETRO_DIR[512];
 int cap32_statusbar=0;
 
+/* atari800 configuration vars */
+extern int Atari800_machine_type;
+extern int Atari800_builtin_basic;
+extern int Atari800_keyboard_leds;
+extern int Atari800_f_keys;
+extern int Atari800_jumper;
+extern int Atari800_builtin_game;
+extern int Atari800_keyboard_detached;
+extern int MEMORY_ram_size;
+extern int Atari800_disable_basic;
+extern int ESC_enable_sio_patch;
+extern int Devices_enable_h_patch;
+extern int Devices_enable_p_patch;
+extern int Devices_enable_r_patch;
+extern int CASSETTE_hold_start;
+
+#define Atari800_TV_UNSET 0
+#define Atari800_TV_PAL 312
+#define Atari800_TV_NTSC 262
+
 #include "cmdline.c"
 
 extern void update_input(void);

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -2,6 +2,9 @@
 
 #include "libretro-core.h"
 #include "atari.h"
+#include "devices.h"
+#include "esc.h"
+#include "memory.h"
 
 cothread_t mainThread;
 cothread_t emuThread;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -1,6 +1,7 @@
 #include "libretro.h"
 
 #include "libretro-core.h"
+#include "atari.h"
 
 cothread_t mainThread;
 cothread_t emuThread;
@@ -32,26 +33,6 @@ extern short signed int SNDBUF[1024*2];
 extern char RPATH[512];
 extern char RETRO_DIR[512];
 int cap32_statusbar=0;
-
-/* atari800 configuration vars */
-extern int Atari800_machine_type;
-extern int Atari800_builtin_basic;
-extern int Atari800_keyboard_leds;
-extern int Atari800_f_keys;
-extern int Atari800_jumper;
-extern int Atari800_builtin_game;
-extern int Atari800_keyboard_detached;
-extern int MEMORY_ram_size;
-extern int Atari800_disable_basic;
-extern int ESC_enable_sio_patch;
-extern int Devices_enable_h_patch;
-extern int Devices_enable_p_patch;
-extern int Devices_enable_r_patch;
-extern int CASSETTE_hold_start;
-
-#define Atari800_TV_UNSET 0
-#define Atari800_TV_PAL 312
-#define Atari800_TV_NTSC 262
 
 #include "cmdline.c"
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -76,7 +76,26 @@ void retro_set_environment(retro_environment_t cb)
   cb( RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports );
 
    struct retro_variable variables[] = {
-
+     {
+       "atari800_system",
+       "Atari System; 400/800 (OS B)|800XL (64K)|130XE (128K)|5200",
+     },
+     {
+       "atari800_ntscpal",
+       "Video Standard; NTSC|PAL",
+     },
+     {
+       "atari800_internalbasic",
+       "Internal BASIC (hold OPTION on boot); disabled|enabled",
+     },
+     {
+       "atari800_sioaccel",
+       "SIO Acceleration; disabled|enabled",
+     },
+     {
+       "atari800_cassboot",
+       "Boot from Cassette; disabled|enabled",
+     },
 	  { 
 		"atari800_opt1",
 		"Autodetect A5200 CartType; disabled|enabled" ,

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -163,8 +163,118 @@ static void update_variables(void)
       texture_init();
       //reset_screen();
    }
-  
 
+   var.key = "atari800_system";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "400/800 (OS B)") == 0)
+	 {
+	   Atari800_machine_type = Atari800_MACHINE_800;
+	   MEMORY_ram_size = 48;
+	   Atari800_builtin_basic = FALSE;
+	   Atari800_keyboard_leds = FALSE;
+	   Atari800_f_keys = FALSE;
+	   Atari800_jumper = FALSE;
+	   Atari800_builtin_game = FALSE;
+	   Atari800_keyboard_detached = FALSE;
+	 }
+       else if (strcmp(var.value, "800XL (64K)") == 0)
+	 {
+	   Atari800_machine_type = Atari800_MACHINE_XLXE;
+	   MEMORY_ram_size = 64;
+	   Atari800_builtin_basic = TRUE;
+	   Atari800_keyboard_leds = FALSE;
+	   Atari800_f_keys = FALSE;
+	   Atari800_jumper = FALSE;
+	   Atari800_builtin_game = FALSE;
+	   Atari800_keyboard_detached = FALSE;
+	 }
+       else if (strcmp(var.value, "130XE (128K)") == 0)
+	 {
+	   Atari800_machine_type = Atari800_MACHINE_XLXE;
+	   MEMORY_ram_size = 128;
+	   Atari800_builtin_basic = TRUE;
+	   Atari800_keyboard_leds = FALSE;
+	   Atari800_f_keys = FALSE;
+	   Atari800_jumper = FALSE;
+	   Atari800_builtin_game = FALSE;
+	   Atari800_keyboard_detached = FALSE;
+	 }
+       else if (strcmp(var.value, "5200") == 0)
+	 {
+	   Atari800_machine_type = Atari800_MACHINE_5200;
+	   MEMORY_ram_size = 16;
+	   Atari800_builtin_basic = FALSE;
+	   Atari800_keyboard_leds = FALSE;
+	   Atari800_f_keys = FALSE;
+	   Atari800_jumper = FALSE;
+	   Atari800_builtin_game = FALSE;
+	   Atari800_keyboard_detached = FALSE;
+	 }
+     }
+   
+   var.key = "atari800_ntscpal";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "enabled") == 0)
+	 {
+	   Atari800_tv_mode = Atari800_TV_NTSC;
+	 }
+       else if (strcmp(var.value, "disabled") == 0)
+	 {
+	   Atari800_tv_mode = Atari800_TV_PAL;
+	 }
+     }
+
+   var.key = "atari800_internalbasic";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "enabled") == 0)
+	 {
+	   Atari800_disable_basic = FALSE;
+	 }
+       else if (strcmp(var.value, "disabled") == 0)
+	 {
+	   Atari800_disable_basic = TRUE;
+	 }
+     }
+
+   var.key = "atari800_sioaccel";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "enabled") == 0)
+	 {
+	   ESC_enable_sio_patch = Devices_enable_h_patch = Devices_enable_p_patch = Devices_enable_r_patch = TRUE;
+	 }
+       else if (strcmp(var.value, "disabled") == 0)
+	 {
+	   ESC_enable_sio_patch = Devices_enable_h_patch = Devices_enable_p_patch = Devices_enable_r_patch = FALSE;	   
+	 }
+     }
+
+   var.key = "atari800_cassboot";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "enabled") == 0)
+	 {
+	   CASSETTE_hold_start=1;
+	 }
+       else if (strcmp(var.value, "disabled") == 0)
+	 {
+	   CASSETTE_hold_start=0;
+	 }
+     }
+   
 }
 
 static void retro_wrap_emulator()

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -6,6 +6,7 @@
 #include "esc.h"
 #include "memory.h"
 #include "cassette.h"
+#include "artifact.h"
 
 cothread_t mainThread;
 cothread_t emuThread;
@@ -100,6 +101,10 @@ void retro_set_environment(retro_environment_t cb)
      {
        "atari800_cassboot",
        "Boot from Cassette; disabled|enabled",
+     },
+     {
+       "atari800_artifacting",
+       "Hi-Res Artifacting; disabled|enabled",
      },
 	  { 
 		"atari800_opt1",
@@ -287,6 +292,39 @@ static void update_variables(void)
 	 {
 	   CASSETTE_hold_start=0;
 	   Atari800_InitialiseMachine();
+	 }
+     }
+
+   var.key = "atari800_artifacting";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+     {
+       if (strcmp(var.value, "enabled") == 0)
+	 {
+	   if (Atari800_tv_mode == Atari800_TV_NTSC)
+	     {
+	       ARTIFACT_Set(ARTIFACT_NTSC_NEW);
+	       ARTIFACT_SetTVMode(Atari800_TV_NTSC);
+	     }
+	   else if (Atari800_tv_mode == Atari800_TV_PAL)
+	     {
+	       ARTIFACT_Set(ARTIFACT_PAL_BLEND);
+	       ARTIFACT_SetTVMode(Atari800_TV_PAL);
+	     }
+	 }
+       else if (strcmp(var.value, "disabled") == 0)
+	 {
+	   if (Atari800_tv_mode == Atari800_TV_NTSC)
+	     {
+	       ARTIFACT_Set(ARTIFACT_NONE);
+	       ARTIFACT_SetTVMode(Atari800_TV_NTSC);
+	     }
+	   else if (Atari800_tv_mode == Atari800_TV_PAL)
+	     {
+	       ARTIFACT_Set(ARTIFACT_NONE);
+	       ARTIFACT_SetTVMode(Atari800_TV_PAL);
+	     }	   
 	 }
      }
    

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -229,11 +229,11 @@ static void update_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
      {
-       if (strcmp(var.value, "enabled") == 0)
+       if (strcmp(var.value, "NTSC") == 0)
 	 {
 	   Atari800_tv_mode = Atari800_TV_NTSC;
 	 }
-       else if (strcmp(var.value, "disabled") == 0)
+       else if (strcmp(var.value, "PAL") == 0)
 	 {
 	   Atari800_tv_mode = Atari800_TV_PAL;
 	 }

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -160,7 +160,7 @@ static void update_variables(void)
       if (pch)
          retroh = strtoul(pch, NULL, 0);
 
-      fprintf(stderr, "[libretro-vice]: Got size: %u x %u.\n", retrow, retroh);
+      fprintf(stderr, "[libretro-atari800]: Got size: %u x %u.\n", retrow, retroh);
 
       CROP_WIDTH =retrow;
       CROP_HEIGHT= (retroh-80);
@@ -184,6 +184,7 @@ static void update_variables(void)
 	   Atari800_jumper = FALSE;
 	   Atari800_builtin_game = FALSE;
 	   Atari800_keyboard_detached = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "800XL (64K)") == 0)
 	 {
@@ -195,6 +196,7 @@ static void update_variables(void)
 	   Atari800_jumper = FALSE;
 	   Atari800_builtin_game = FALSE;
 	   Atari800_keyboard_detached = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "130XE (128K)") == 0)
 	 {
@@ -206,6 +208,7 @@ static void update_variables(void)
 	   Atari800_jumper = FALSE;
 	   Atari800_builtin_game = FALSE;
 	   Atari800_keyboard_detached = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "5200") == 0)
 	 {
@@ -217,6 +220,7 @@ static void update_variables(void)
 	   Atari800_jumper = FALSE;
 	   Atari800_builtin_game = FALSE;
 	   Atari800_keyboard_detached = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
      }
    
@@ -243,10 +247,12 @@ static void update_variables(void)
        if (strcmp(var.value, "enabled") == 0)
 	 {
 	   Atari800_disable_basic = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "disabled") == 0)
 	 {
 	   Atari800_disable_basic = TRUE;
+	   Atari800_InitialiseMachine();
 	 }
      }
 
@@ -258,10 +264,12 @@ static void update_variables(void)
        if (strcmp(var.value, "enabled") == 0)
 	 {
 	   ESC_enable_sio_patch = Devices_enable_h_patch = Devices_enable_p_patch = Devices_enable_r_patch = TRUE;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "disabled") == 0)
 	 {
-	   ESC_enable_sio_patch = Devices_enable_h_patch = Devices_enable_p_patch = Devices_enable_r_patch = FALSE;	   
+	   ESC_enable_sio_patch = Devices_enable_h_patch = Devices_enable_p_patch = Devices_enable_r_patch = FALSE;
+	   Atari800_InitialiseMachine();
 	 }
      }
 
@@ -273,10 +281,12 @@ static void update_variables(void)
        if (strcmp(var.value, "enabled") == 0)
 	 {
 	   CASSETTE_hold_start=1;
+	   Atari800_InitialiseMachine();
 	 }
        else if (strcmp(var.value, "disabled") == 0)
 	 {
 	   CASSETTE_hold_start=0;
+	   Atari800_InitialiseMachine();
 	 }
      }
    

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -5,6 +5,7 @@
 #include "devices.h"
 #include "esc.h"
 #include "memory.h"
+#include "cassette.h"
 
 cothread_t mainThread;
 cothread_t emuThread;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -304,7 +304,7 @@ static void update_variables(void)
 	 {
 	   if (Atari800_tv_mode == Atari800_TV_NTSC)
 	     {
-	       ARTIFACT_Set(ARTIFACT_NTSC_NEW);
+	       ARTIFACT_Set(ARTIFACT_NTSC_OLD);
 	       ARTIFACT_SetTVMode(Atari800_TV_NTSC);
 	     }
 	   else if (Atari800_tv_mode == Atari800_TV_PAL)

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -309,7 +309,7 @@ static void update_variables(void)
 	     }
 	   else if (Atari800_tv_mode == Atari800_TV_PAL)
 	     {
-	       ARTIFACT_Set(ARTIFACT_PAL_BLEND);
+	       ARTIFACT_Set(ARTIFACT_NONE); // PAL Blending has been flipped off in config for now.
 	       ARTIFACT_SetTVMode(Atari800_TV_PAL);
 	     }
 	 }

--- a/libretro/libretro-core.h
+++ b/libretro/libretro-core.h
@@ -43,7 +43,7 @@ extern int pauseg;
 
 #if  defined(__ANDROID__) || defined(ANDROID)
 #include <android/log.h>
-#define LOG_TAG "RetroArch.Vice"
+#define LOG_TAG "RetroArch.Atari800"
 #define LOGI(...)  __android_log_print(ANDROID_LOG_INFO,LOG_TAG,__VA_ARGS__)
 #else
 #define LOGI printf


### PR DESCRIPTION
Add core options much needed for real use of the Atari 800 core:

* System type (most effective system models, 400/800 (48K), 800XL, 130XE, and 5200. Some XL/XE models adding soon (320K, and 1088K for certain games that take advantage of it, e.g. Atari Blast and Yoomp!)
* Video standard (NTSC / PAL)
* SIO Acelleration (many copy protections fail unless this is explicitly disabled)
* Hi-Res Artifacting - Some games rely explicitly on color clock artifacting to provide color in hi-res (mode F)
* Cassette boot - Hold start when booting, allowing bootable cassette images to work.
* Internal Basic (easy way for games requiring Atari BASIC to run)