### PR TITLE
Fixed SHIFT and CTRL keys, 4 controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,61 @@
+This is an updated version of lr-atari800 to add in missing features.
+
+1) full keyboard support including the SHIFT and CTRL keys, so you can type all the characters. Useful for adventure games, programming in BASIC, etc.
+
+2) four controller support when the emulator is set to 400/800 (useful for games like M.U.L.E.) Note that only the 400/800 had four joystick ports. See http://www.atarimania.com/faq-atari-400-800-xl-xe-what-games-support-4-or-more-simultaneous-players_93.html for a list of games that support four controllers.
+
+
 WIP Libretro port of Atari800 emulator version 3.1.0
 ----------------------------------------------------
 
 In joy mode
 
 L3  NA
+
 R3  NA 
+
 L2  KEY SPACE
+
 R2  KEY ESCAPE
+
 L   CONSOL_OPTION
+
 R   TOGGLE UI
+
 SEL CONSOL_SELECT
+
 STR CONSOL_START
+
 A   FIRE1/KEY RETURN IN GUI
+
 B   KEY RETURN 
+
 X   FIRE2/KEY ESCAPE IN GUI
+
 Y   VKBD ON/OFF
 
-In Keayboard mode
+In Keyboard mode
 
 F1 MAIN GUI
+
 F2 CONSOL_OPTION
+
 F3 CONSOL_SELECT
+
 F4 CONSOL_START
+
 UP
+
 DOWN
+
 LEFT
+
 RIGHT
+
 RETURN 
+
 ESCAPE 
+
 SPACE
 
 

--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -387,26 +387,26 @@ void Process_key()
 				if(i==RETROK_F12){
 					continue;
 				}
-
+*/
 				if(i==RETROK_RCTRL){
-					//CTRLON=-CTRLON;
+					CTRLON=-CTRLON;
 					printf("Modifier crtl pressed %d \n",CTRLON); 
 					continue;
 				}
 				if(i==RETROK_RSHIFT){
-					//SHITFON=-SHITFON;
+					SHIFTON=-SHIFTON;
 					printf("Modifier shift pressed %d \n",SHIFTON); 
 					continue;
 				}
 
 				if(i==RETROK_LALT){
-					//KBMOD=-KBMOD;
+					KBMOD=-KBMOD;
 					printf("Modifier alt pressed %d \n",KBMOD); 
 					continue;
 				}
 				//printf("press: %d \n",i);
 				//retro_key_down(i);
-*/	
+	
         	}	
         	else if ( !Key_Sate[i] && Key_Sate[i]!=old_Key_Sate[i]  )
         	{
@@ -414,7 +414,7 @@ void Process_key()
 				if(i==RETROK_F12){
  					continue;
 				}
-
+*/
 				if(i==RETROK_RCTRL){
 					CTRLON=-CTRLON;
 					printf("Modifier crtl released %d \n",CTRLON); 
@@ -427,11 +427,11 @@ void Process_key()
 				}
 
 				if(i==RETROK_LALT){
-//					KBMOD=-KBMOD;
+					KBMOD=-KBMOD;
 					printf("Modifier alt released %d \n",KBMOD); 
 					continue;
 				}
-*/
+
 				//printf("release: %d \n",i);
 				//retro_key_up(i);
 	

--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -63,7 +63,7 @@ int touch=-1; // gui mouse btn
 //JOY
 int al[2][2];//left analog1
 int ar[2][2];//right analog1
-unsigned char MXjoy[2]; // joy
+unsigned char MXjoy[4]; // joy
 
 #define JOYRANGE_UP_VALUE     -16384     /* Joystick ranges in XY */
 #define JOYRANGE_DOWN_VALUE    16383
@@ -171,7 +171,7 @@ int RSTOPON=-1;
 int CTRLON=-1;
 
 extern unsigned short int bmp[400*300];
-extern unsigned atari_devices[ 2 ];
+extern unsigned atari_devices[ 4 ];
 
 extern int UI_is_active;
 extern int CURRENT_TV;
@@ -401,13 +401,13 @@ void Process_key()
 
 				if(i==RETROK_LALT){
 					KBMOD=-KBMOD;
-					printf("Modifier alt pressed %d \n",KBMOD); 
+					printf("Modifier alt pressed %d \n",KBMOD);
 					continue;
 				}
 				//printf("press: %d \n",i);
 				//retro_key_down(i);
-	
-        	}	
+
+        	}
         	else if ( !Key_Sate[i] && Key_Sate[i]!=old_Key_Sate[i]  )
         	{
 /*
@@ -417,25 +417,25 @@ void Process_key()
 */
 				if(i==RETROK_RCTRL){
 					CTRLON=-CTRLON;
-					printf("Modifier crtl released %d \n",CTRLON); 
+					printf("Modifier crtl released %d \n",CTRLON);
 					continue;
 				}
 				if(i==RETROK_RSHIFT){
 					SHIFTON=-SHIFTON;
-					printf("Modifier shift released %d \n",SHIFTON); 
+					printf("Modifier shift released %d \n",SHIFTON);
 					continue;
 				}
 
 				if(i==RETROK_LALT){
 					KBMOD=-KBMOD;
-					printf("Modifier alt released %d \n",KBMOD); 
+					printf("Modifier alt released %d \n",KBMOD);
 					continue;
 				}
 
 				//printf("release: %d \n",i);
 				//retro_key_up(i);
-	
-        	}	
+
+        	}
 
 	memcpy(old_Key_Sate,Key_Sate , sizeof(Key_Sate) );
 
@@ -446,9 +446,11 @@ int Retro_PollEvent()
     //   RETRO        B    Y    SLT  STA  UP   DWN  LEFT RGT  A    X    L    R    L2   R2   L3   R3
     //   INDEX        0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15
 
-   int SAVPAS=PAS;	
+   int SAVPAS=PAS;
    int i,j;
-   static int vbt[2][16]={
+   static int vbt[4][16]={
+		{0x0,0x0,0x0,0x0,0x01,0x02,0x04,0x08,0x80,0x40,0x0,0x0,0x0,0x0,0x0,0x0},
+		{0x0,0x0,0x0,0x0,0x01,0x02,0x04,0x08,0x80,0x40,0x0,0x0,0x0,0x0,0x0,0x0},
 		{0x0,0x0,0x0,0x0,0x01,0x02,0x04,0x08,0x80,0x40,0x0,0x0,0x0,0x0,0x0,0x0},
 		{0x0,0x0,0x0,0x0,0x01,0x02,0x04,0x08,0x80,0x40,0x0,0x0,0x0,0x0,0x0,0x0},
 	};
@@ -462,15 +464,16 @@ int Retro_PollEvent()
 
    if(SHOWKEY==-1 && pauseg==0)Process_key();
 
-
-	  //Joy mode
-   for(j=0;j<2;j++){
+   //Joy mode
+   for(j=0;j<4;j++){
 
       for(i=4;i<10;i++)
       {
-         if( input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, i))
-            MXjoy[j] |= vbt[j][i]; // Joy press	
-		 else if( MXjoy[j]&vbt[j][i])MXjoy[j] &= ~vbt[j][i]; // Joy press
+         if( input_state_cb(j, RETRO_DEVICE_JOYPAD, 0, i)) {
+            MXjoy[j] |= vbt[j][i]; // Joy press
+	    fprintf(stderr, "[Libretro-atari800]: MXjoy press controller %u slot %u.\n", j, i);
+	}
+	 else if( MXjoy[j]&vbt[j][i])MXjoy[j] &= ~vbt[j][i]; // Joy press
       }
 
   }
@@ -505,8 +508,10 @@ int Retro_PollEvent()
    //	     0    1    2    3
    	for(i=0;i<4;i++){
 
-	   if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 )
+	   if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 ) {
 	      mbt[i]=1;
+	      fprintf(stderr, "[Libretro-atari800]: atari_devices press slot %u.\n", i);
+	   }
 	   else if ( mbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
 	   {
 	      mbt[i]=0;
@@ -517,8 +522,10 @@ int Retro_PollEvent()
    //        10   11   12   13   14   15
    	for(i=10;i<16;i++){
 
-	   if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 )
+	   if ( input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) && mbt[i]==0 ) {
+	      fprintf(stderr, "[Libretro-atari800]: atari_devices press slot %u.\n", i);
 	      mbt[i]=1;
+	   }
 	   else if ( mbt[i]==1 && ! input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i) )
 	   {
 	      mbt[i]=0;
@@ -559,7 +566,7 @@ int Retro_PollEvent()
 
    if(mmbL==0 && mouse_l){
 
-      mmbL=1;		
+      mmbL=1;
       pushi=1;
       touch=1;
 
@@ -572,7 +579,7 @@ int Retro_PollEvent()
    }
 
    if(mmbR==0 && mouse_r){
-      mmbR=1;		
+      mmbR=1;
    }
    else if(mmbR==1 && !mouse_r) {
       mmbR=0;

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -20,7 +20,7 @@ int retroh=300;
 #define RETRO_DEVICE_ATARI_KEYBOARD RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_KEYBOARD, 0)
 #define RETRO_DEVICE_ATARI_JOYSTICK RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
 
-unsigned atari_devices[ 2 ];
+unsigned atari_devices[ 4 ];
 
 int keyboard_type=0;
 int autorun5200=0;
@@ -72,11 +72,20 @@ void retro_set_environment(retro_environment_t cb)
     { "ATARI Joystick", RETRO_DEVICE_ATARI_JOYSTICK },
     { "ATARI Keyboard", RETRO_DEVICE_ATARI_KEYBOARD },
   };
-
+  static const struct retro_controller_description p3_controllers[] = {
+    { "ATARI Joystick", RETRO_DEVICE_ATARI_JOYSTICK },
+    { "ATARI Keyboard", RETRO_DEVICE_ATARI_KEYBOARD },
+  };
+  static const struct retro_controller_description p4_controllers[] = {
+    { "ATARI Joystick", RETRO_DEVICE_ATARI_JOYSTICK },
+    { "ATARI Keyboard", RETRO_DEVICE_ATARI_KEYBOARD },
+  };
 
   static const struct retro_controller_info ports[] = {
     { p1_controllers, 2  }, // port 1
     { p2_controllers, 2  }, // port 2
+    { p3_controllers, 2  }, // port 3
+    { p4_controllers, 2  }, // port 4
     { NULL, 0 }
   };
 
@@ -551,7 +560,7 @@ unsigned retro_api_version(void)
 
 void retro_set_controller_port_device( unsigned port, unsigned device )
 {
-  if ( port < 2 )
+  if ( port < 4 )
   {
     atari_devices[ port ] = device;
 

--- a/libretro/platform.c
+++ b/libretro/platform.c
@@ -49,7 +49,9 @@ extern int UI_is_active;
 static int swap_joysticks = FALSE;
 int PLATFORM_kbd_joy_0_enabled = TRUE;	/* enabled by default, doesn't hurt */
 int PLATFORM_kbd_joy_1_enabled = TRUE;//FALSE;	/* disabled, would steal normal keys */
-extern unsigned char MXjoy[2]; // joy
+int PLATFORM_kbd_joy_2_enabled = TRUE;//FALSE;	/* disabled, would steal normal keys */
+int PLATFORM_kbd_joy_3_enabled = TRUE;//FALSE;	/* disabled, would steal normal keys */
+extern unsigned char MXjoy[4]; // joy
 extern int mbt[16];
 extern int retro_sound_finalized;
 
@@ -655,10 +657,10 @@ void PLATFORM_PaletteUpdate(void)
 	retro_PaletteUpdate();
 }
 
-static void get_platform_PORT(unsigned char *s0, unsigned char *s1)
+static void get_platform_PORT(unsigned char *s0, unsigned char *s1, unsigned char *s2, unsigned char *s3)
 {
-	int stick0, stick1;
-	stick0 = stick1 = INPUT_STICK_CENTRE;
+	int stick0, stick1, stick2, stick3;
+	stick0 = stick1 = stick2 = stick3 = INPUT_STICK_CENTRE;
 
 	if (PLATFORM_kbd_joy_0_enabled) {
 		if (MXjoy[0]&0x04)
@@ -680,24 +682,47 @@ static void get_platform_PORT(unsigned char *s0, unsigned char *s1)
 			stick1 &= INPUT_STICK_FORWARD;
 		if (MXjoy[1]&0x02)
 			stick1 &= INPUT_STICK_BACK;
-
+	}
+	if (PLATFORM_kbd_joy_2_enabled) {
+		if (MXjoy[2]&0x04)
+			stick2 &= INPUT_STICK_LEFT;
+		if (MXjoy[2]&0x08)
+			stick2 &= INPUT_STICK_RIGHT;
+		if (MXjoy[2]&0x01)
+			stick2 &= INPUT_STICK_FORWARD;
+		if (MXjoy[2]&0x02)
+			stick2 &= INPUT_STICK_BACK;
+	}
+	if (PLATFORM_kbd_joy_3_enabled) {
+		if (MXjoy[3]&0x04)
+			stick3 &= INPUT_STICK_LEFT;
+		if (MXjoy[3]&0x08)
+			stick3 &= INPUT_STICK_RIGHT;
+		if (MXjoy[3]&0x01)
+			stick3 &= INPUT_STICK_FORWARD;
+		if (MXjoy[3]&0x02)
+			stick3 &= INPUT_STICK_BACK;
 	}
 
 	if (swap_joysticks) {
 		*s1 = stick0;
 		*s0 = stick1;
+		*s2 = stick2;
+		*s3 = stick3;
 	}
 	else {
 		*s0 = stick0;
 		*s1 = stick1;
+		*s2 = stick2;
+		*s3 = stick3;
 	}
 
  }
 
-static void get_platform_TRIG(unsigned char *t0, unsigned char *t1)
+static void get_platform_TRIG(unsigned char *t0, unsigned char *t1, unsigned char *t2, unsigned char *t3)
 {
-	int trig0, trig1;
-	trig0 = trig1 = 1;
+	int trig0, trig1, trig2, trig3;
+	trig0 = trig1 = trig2 = trig3 = 1;
 
 	if (PLATFORM_kbd_joy_0_enabled) {
 		trig0 = MXjoy[0]&0x80?0:1;
@@ -707,13 +732,25 @@ static void get_platform_TRIG(unsigned char *t0, unsigned char *t1)
 		trig1 = MXjoy[1]&0x80?0:1;
 	}
 
+	if (PLATFORM_kbd_joy_2_enabled) {
+		trig2 = MXjoy[2]&0x80?0:1;
+	}
+
+	if (PLATFORM_kbd_joy_3_enabled) {
+		trig3 = MXjoy[3]&0x80?0:1;
+	}
+
 	if (swap_joysticks) {
 		*t1 = trig0;
 		*t0 = trig1;
+		*t2 = trig2;
+		*t3 = trig3;
 	}
 	else {
 		*t0 = trig0;
 		*t1 = trig1;
+		*t2 = trig2;
+		*t3 = trig3;
 	}
 
 }
@@ -721,10 +758,16 @@ static void get_platform_TRIG(unsigned char *t0, unsigned char *t1)
 int PLATFORM_PORT(int num)
 {
 	if (num == 0) {
-		UBYTE a, b;
-		get_platform_PORT(&a, &b);
+		UBYTE a, b, c, d;
+		get_platform_PORT(&a, &b, &c, &d);
 
 		return (b << 4) | (a & 0x0f);
+	}
+	if (num == 1) {
+		UBYTE a, b, c, d;
+		get_platform_PORT(&a, &b, &c, &d);
+
+		return (d << 4) | (c & 0x0f);
 	}
 
 	return 0xff;
@@ -732,14 +775,18 @@ int PLATFORM_PORT(int num)
 
 int PLATFORM_TRIG(int num)
 {
-	UBYTE a, b;
-	get_platform_TRIG(&a, &b);
+	UBYTE a, b, c, d;
+	get_platform_TRIG(&a, &b, &c, &d);
 
 	switch (num) {
 	case 0:
 		return a;
 	case 1:
 		return b;
+	case 2:
+		return c;
+	case 3:
+		return d;
 	default:
 		break;
 	}

--- a/libretro/platform.c
+++ b/libretro/platform.c
@@ -423,111 +423,145 @@ int PLATFORM_Keyboard(void)
 			return AKEY_CTRL_8|shiftctrl;
 		if (Key_Sate[RETROK_9])	
 			return AKEY_CTRL_9|shiftctrl;
+
+		if (Key_Sate[RETROK_a])return AKEY_CTRL_a;
+		if (Key_Sate[RETROK_b])return AKEY_CTRL_b;
+		if (Key_Sate[RETROK_c])return AKEY_CTRL_c;
+		if (Key_Sate[RETROK_d])return AKEY_CTRL_d;
+		if (Key_Sate[RETROK_e])return AKEY_CTRL_e;
+		if (Key_Sate[RETROK_f])return AKEY_CTRL_f;
+		if (Key_Sate[RETROK_g])return AKEY_CTRL_g;
+		if (Key_Sate[RETROK_h])return AKEY_CTRL_h;
+		if (Key_Sate[RETROK_i])return AKEY_CTRL_i;
+		if (Key_Sate[RETROK_j])return AKEY_CTRL_j;
+		if (Key_Sate[RETROK_k])return AKEY_CTRL_k;
+		if (Key_Sate[RETROK_l])return AKEY_CTRL_l;
+		if (Key_Sate[RETROK_m])return AKEY_CTRL_m;
+		if (Key_Sate[RETROK_n])return AKEY_CTRL_n;
+		if (Key_Sate[RETROK_o])return AKEY_CTRL_o;
+		if (Key_Sate[RETROK_p])return AKEY_CTRL_p;
+		if (Key_Sate[RETROK_q])return AKEY_CTRL_q;
+		if (Key_Sate[RETROK_r])return AKEY_CTRL_r;
+		if (Key_Sate[RETROK_s])return AKEY_CTRL_s;
+		if (Key_Sate[RETROK_t])return AKEY_CTRL_t;
+		if (Key_Sate[RETROK_u])return AKEY_CTRL_u;
+		if (Key_Sate[RETROK_v])return AKEY_CTRL_v;
+		if (Key_Sate[RETROK_w])return AKEY_CTRL_w;
+		if (Key_Sate[RETROK_x])return AKEY_CTRL_x;
+		if (Key_Sate[RETROK_y])return AKEY_CTRL_y;
+		if (Key_Sate[RETROK_z])return AKEY_CTRL_z;
+
+		/* these three keys also type control-graphics characters, but
+		   there don't seem to be AKEY_ values for them! */
+		if (Key_Sate[RETROK_COMMA])return (AKEY_CTRL | AKEY_COMMA);
+		if (Key_Sate[RETROK_PERIOD])return (AKEY_CTRL | AKEY_FULLSTOP);
+		if (Key_Sate[RETROK_SEMICOLON])return (AKEY_CTRL | AKEY_SEMICOLON);
+
 	}
 
+	/* handle all keys */
 
-	/* FIXME handle all keys */
+	if (INPUT_key_shift) {
+		if (Key_Sate[RETROK_a])return AKEY_A;
+		if (Key_Sate[RETROK_b])return AKEY_B;
+		if (Key_Sate[RETROK_c])return AKEY_C;
+		if (Key_Sate[RETROK_d])return AKEY_D;
+		if (Key_Sate[RETROK_e])return AKEY_E;
+		if (Key_Sate[RETROK_f])return AKEY_F;
+		if (Key_Sate[RETROK_g])return AKEY_G;
+		if (Key_Sate[RETROK_h])return AKEY_H;
+		if (Key_Sate[RETROK_i])return AKEY_I;
+		if (Key_Sate[RETROK_j])return AKEY_J;
+		if (Key_Sate[RETROK_k])return AKEY_K;
+		if (Key_Sate[RETROK_l])return AKEY_L;
+		if (Key_Sate[RETROK_m])return AKEY_M;
+		if (Key_Sate[RETROK_n])return AKEY_N;
+		if (Key_Sate[RETROK_o])return AKEY_O;
+		if (Key_Sate[RETROK_p])return AKEY_P;
+		if (Key_Sate[RETROK_q])return AKEY_Q;
+		if (Key_Sate[RETROK_r])return AKEY_R;
+		if (Key_Sate[RETROK_s])return AKEY_S;
+		if (Key_Sate[RETROK_t])return AKEY_T;
+		if (Key_Sate[RETROK_u])return AKEY_U;
+		if (Key_Sate[RETROK_v])return AKEY_V;
+		if (Key_Sate[RETROK_w])return AKEY_W;
+		if (Key_Sate[RETROK_x])return AKEY_X;
+		if (Key_Sate[RETROK_y])return AKEY_Y;
+		if (Key_Sate[RETROK_z])return AKEY_Z;
 
-	if (Key_Sate[RETROK_a])return AKEY_A;
-	if (Key_Sate[RETROK_b])return AKEY_B;
-	if (Key_Sate[RETROK_c])return AKEY_C;
-	if (Key_Sate[RETROK_d])return AKEY_D;
-	if (Key_Sate[RETROK_e])return AKEY_E;
-	if (Key_Sate[RETROK_f])return AKEY_F;
-	if (Key_Sate[RETROK_g])return AKEY_G;
-	if (Key_Sate[RETROK_h])return AKEY_H;
-	if (Key_Sate[RETROK_i])return AKEY_I;
-	if (Key_Sate[RETROK_j])return AKEY_J;
-	if (Key_Sate[RETROK_k])return AKEY_K;
-	if (Key_Sate[RETROK_l])return AKEY_L;
-	if (Key_Sate[RETROK_m])return AKEY_M;
-	if (Key_Sate[RETROK_n])return AKEY_N;
-	if (Key_Sate[RETROK_o])return AKEY_O;
-	if (Key_Sate[RETROK_p])return AKEY_P;
-	if (Key_Sate[RETROK_q])return AKEY_Q;
-	if (Key_Sate[RETROK_r])return AKEY_R;
-	if (Key_Sate[RETROK_s])return AKEY_S;
-	if (Key_Sate[RETROK_t])return AKEY_T;
-	if (Key_Sate[RETROK_u])return AKEY_U;
-	if (Key_Sate[RETROK_v])return AKEY_V;
-	if (Key_Sate[RETROK_w])return AKEY_W;
-	if (Key_Sate[RETROK_x])return AKEY_X;
-	if (Key_Sate[RETROK_y])return AKEY_Y;
-	if (Key_Sate[RETROK_z])return AKEY_Z;
+		if (Key_Sate[RETROK_1])return AKEY_EXCLAMATION;
+		if (Key_Sate[RETROK_2])return AKEY_AT;
+		if (Key_Sate[RETROK_3])return AKEY_HASH;
+		if (Key_Sate[RETROK_4])return AKEY_DOLLAR;
+		if (Key_Sate[RETROK_5])return AKEY_PERCENT;
+		if (Key_Sate[RETROK_6])return AKEY_CARET;
+		if (Key_Sate[RETROK_7])return AKEY_AMPERSAND;
+		if (Key_Sate[RETROK_8])return AKEY_ASTERISK;
+		if (Key_Sate[RETROK_9])return AKEY_PARENLEFT;
+		if (Key_Sate[RETROK_0])return AKEY_PARENRIGHT;
 
-	if (Key_Sate[RETROK_0])return AKEY_0;
-	if (Key_Sate[RETROK_1])return AKEY_1;
-	if (Key_Sate[RETROK_2])return AKEY_2;
-	if (Key_Sate[RETROK_3])return AKEY_3;
-	if (Key_Sate[RETROK_4])return AKEY_4;
-	if (Key_Sate[RETROK_5])return AKEY_5;
-	if (Key_Sate[RETROK_6])return AKEY_6;
-	if (Key_Sate[RETROK_7])return AKEY_7;
-	if (Key_Sate[RETROK_8])return AKEY_8;
-	if (Key_Sate[RETROK_9])return AKEY_9;
+		if (Key_Sate[RETROK_BACKSLASH])return AKEY_BAR;
+		if (Key_Sate[RETROK_COMMA])return AKEY_LESS;
+		if (Key_Sate[RETROK_PERIOD])return AKEY_GREATER;
+		if (Key_Sate[RETROK_MINUS])return AKEY_UNDERSCORE;
+		if (Key_Sate[RETROK_EQUALS])return AKEY_PLUS;
+		if (Key_Sate[RETROK_LEFTBRACKET])return AKEY_BRACKETLEFT; // no curly braces on Atari
+		if (Key_Sate[RETROK_RIGHTBRACKET])return AKEY_BRACKETRIGHT; // no curly braces on Atari
+		if (Key_Sate[RETROK_SEMICOLON])return AKEY_COLON;
+		if (Key_Sate[RETROK_QUOTE])return AKEY_DBLQUOTE;
+		if (Key_Sate[RETROK_SLASH])return AKEY_QUESTION;
 
-//	if (Key_Sate[RETROK_SPACE])return AKEY_SPACE;
-//	if (Key_Sate[RETROK_BACKQUOTE])return AKEY_NONE; //???
-	if (Key_Sate[RETROK_BACKSLASH])return AKEY_BACKSLASH;
-	if (Key_Sate[RETROK_COMMA])return AKEY_COMMA;
-	if (Key_Sate[RETROK_PERIOD])return AKEY_FULLSTOP;
-	if (Key_Sate[RETROK_MINUS])return AKEY_MINUS;
-	if (Key_Sate[RETROK_EQUALS])return AKEY_EQUAL;
-	if (Key_Sate[RETROK_LEFTBRACKET])return AKEY_BRACKETLEFT;
-	if (Key_Sate[RETROK_RIGHTBRACKET])return AKEY_BRACKETRIGHT;
-	if (Key_Sate[RETROK_SEMICOLON])return AKEY_SEMICOLON;
-	if (Key_Sate[RETROK_QUOTE])return AKEY_QUOTE;
-	if (Key_Sate[RETROK_SLASH])return AKEY_SLASH;
+	} else {
+		if (Key_Sate[RETROK_a])return AKEY_a;
+		if (Key_Sate[RETROK_b])return AKEY_b;
+		if (Key_Sate[RETROK_c])return AKEY_c;
+		if (Key_Sate[RETROK_d])return AKEY_d;
+		if (Key_Sate[RETROK_e])return AKEY_e;
+		if (Key_Sate[RETROK_f])return AKEY_f;
+		if (Key_Sate[RETROK_g])return AKEY_g;
+		if (Key_Sate[RETROK_h])return AKEY_h;
+		if (Key_Sate[RETROK_i])return AKEY_i;
+		if (Key_Sate[RETROK_j])return AKEY_j;
+		if (Key_Sate[RETROK_k])return AKEY_k;
+		if (Key_Sate[RETROK_l])return AKEY_l;
+		if (Key_Sate[RETROK_m])return AKEY_m;
+		if (Key_Sate[RETROK_n])return AKEY_n;
+		if (Key_Sate[RETROK_o])return AKEY_o;
+		if (Key_Sate[RETROK_p])return AKEY_p;
+		if (Key_Sate[RETROK_q])return AKEY_q;
+		if (Key_Sate[RETROK_r])return AKEY_r;
+		if (Key_Sate[RETROK_s])return AKEY_s;
+		if (Key_Sate[RETROK_t])return AKEY_t;
+		if (Key_Sate[RETROK_u])return AKEY_u;
+		if (Key_Sate[RETROK_v])return AKEY_v;
+		if (Key_Sate[RETROK_w])return AKEY_w;
+		if (Key_Sate[RETROK_x])return AKEY_x;
+		if (Key_Sate[RETROK_y])return AKEY_y;
+		if (Key_Sate[RETROK_z])return AKEY_z;
 
-//	if (Key_Sate[RETROK_ESCAPE])return AKEY_ESCAPE;
-//	if (Key_Sate[RETROK_RETURN])return AKEY_RETURN;
-//	if (Key_Sate[RETROK_BACKSPACE])return AKEY_BACKSPACE;
-//	if (Key_Sate[RETROK_DELETE])return AKEY_DELETE_CHAR;
-//	if (Key_Sate[RETROK_INSERT])return AKEY_INSERT_CHAR;
-//	if (Key_Sate[RETROK_HOME])return AKEY_CLEAR;
-//	if (Key_Sate[RETROK_END])return AKEY_HELP;
-//	if (Key_Sate[RETROK_PAGEUP])return AKEY_F1 | AKEY_SHFT;
-//	if (Key_Sate[RETROK_PAGEDOWN])return AKEY_F2 | AKEY_SHFT;
+		if (Key_Sate[RETROK_0])return AKEY_0;
+		if (Key_Sate[RETROK_1])return AKEY_1;
+		if (Key_Sate[RETROK_2])return AKEY_2;
+		if (Key_Sate[RETROK_3])return AKEY_3;
+		if (Key_Sate[RETROK_4])return AKEY_4;
+		if (Key_Sate[RETROK_5])return AKEY_5;
+		if (Key_Sate[RETROK_6])return AKEY_6;
+		if (Key_Sate[RETROK_7])return AKEY_7;
+		if (Key_Sate[RETROK_8])return AKEY_8;
+		if (Key_Sate[RETROK_9])return AKEY_9;
 
-//	if (Key_Sate[RETROK_LCTRL])return AKEY_75;
-//	if (Key_Sate[RETROK_TAB])return AKEY_TAB;
-//	if (Key_Sate[RETROK_RCTRL])return AKEY_75;
-//	if (Key_Sate[RETROK_LSHIFT])return AKEY_17;
-//	if (Key_Sate[RETROK_RSHIFT])return AKEY_64;
-//	if (Key_Sate[RETROK_LALT])return AKEY_64;
-//	if (Key_Sate[RETROK_LMETA])return AKEY_75;
-//	if (Key_Sate[RETROK_RALT])return AKEY_64;
-//	if (Key_Sate[RETROK_RMETA])return AKEY_75;
+		if (Key_Sate[RETROK_BACKSLASH])return AKEY_BACKSLASH;
+		if (Key_Sate[RETROK_COMMA])return AKEY_COMMA;
+		if (Key_Sate[RETROK_PERIOD])return AKEY_FULLSTOP;
+		if (Key_Sate[RETROK_MINUS])return AKEY_MINUS;
+		if (Key_Sate[RETROK_EQUALS])return AKEY_EQUAL;
+		if (Key_Sate[RETROK_LEFTBRACKET])return AKEY_BRACKETLEFT;
+		if (Key_Sate[RETROK_RIGHTBRACKET])return AKEY_BRACKETRIGHT;
+		if (Key_Sate[RETROK_SEMICOLON])return AKEY_SEMICOLON;
+		if (Key_Sate[RETROK_QUOTE])return AKEY_QUOTE;
+		if (Key_Sate[RETROK_SLASH])return AKEY_SLASH;
 
-//	if (Key_Sate[RETROK_UP])return AKEY_07)| 0x80;
-//	if (Key_Sate[RETROK_DOWN])return AKEY_07;
-//	if (Key_Sate[RETROK_LEFT])return AKEY_02) | 0x80;
-//	if (Key_Sate[RETROK_RIGHT])return AKEY_02;
-
-//	if (Key_Sate[RETROK_F1])return AKEY_04;
-//	if (Key_Sate[RETROK_F2])return AKEY_04) | 0x80;
-//	if (Key_Sate[RETROK_F3])return AKEY_05;
-//	if (Key_Sate[RETROK_F4])return AKEY_05) | 0x80;
-//	if (Key_Sate[RETROK_F5])return AKEY_06;
-//	if (Key_Sate[RETROK_F6])return AKEY_06) | 0x80;
-//	if (Key_Sate[RETROK_F7])return AKEY_03;
-//	if (Key_Sate[RETROK_F8])return AKEY_03) | 0x80;
-/*
-	if (Key_Sate[RETROK_KP0]
-	if (Key_Sate[RETROK_KP5])return AKEY_03);
-	if (Key_Sate[RETROK_KP1])return AKEY_03);
-	if (Key_Sate[RETROK_KP2])return AKEY_03);
-	if (Key_Sate[RETROK_KP3])return AKEY_03);
-	if (Key_Sate[RETROK_KP4])return AKEY_03);
-	if (Key_Sate[RETROK_KP6])return AKEY_03);
-	if (Key_Sate[RETROK_KP7])return AKEY_03);
-	if (Key_Sate[RETROK_KP8])return AKEY_03);
-	if (Key_Sate[RETROK_KP9])return AKEY_03);
-*/
-/*
-	if (Key_Sate[RETROK_KP_DIVIDE])return AKEY_67;
-	if (Key_Sate[RETROK_KP_ENTER])return AKEY_01;
-*/
+	}
 
 	/* FIXME joy bind */
 


### PR DESCRIPTION
This should address issue [#26](https://github.com/libretro/libretro-atari800/issues/26)

The problem was that there were not tables for the shifted or ctrl-shifted characters. With these additions all the shifted punctuation as well as all the graphical characters should now be able to be typed using a standard keyboard.
