### PR TITLE
Build utf encoding

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -14,6 +14,8 @@ SOURCES_C := \
 
 SOURCES_C += $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 	$(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
+	$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
+	$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
 	$(LIBRETRO_COMM_DIR)/file/file_path.c \
 	$(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 	$(LIBRETRO_COMM_DIR)/vfs/vfs_implementation.c


### PR DESCRIPTION
My Windows cross-compile was failing since the vfs impl was added to the list of files being compiled. These contain the missing symbols.