### PR TITLE
Add car, com and xex to valid extensions

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -596,7 +596,7 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
    info->library_name     = "Atari800";
    info->library_version  = "3.1.0" GIT_VERSION;
-   info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx";
+   info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|com|xex";
    info->need_fullpath    = true;
    info->block_extract = false;
 


### PR DESCRIPTION
CAR is the standard format/extension for Atari cartridge dumps - see also atari800/DOC/cart.txt

COM is the standard extension for Atari computer binary (compound) files, XEX is widely used on DOS/Windows systems instead so the files can be distinguished from native DOS/Windows COM files.