### PR TITLE
retrofw target remove findstring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ else ifeq ($(platform), classic_armv8_a35)
 #######################################
 
 #RETROFW
-else ifneq (,$(findstring retrofw,$(platform)))
+else ifeq ($(platform), retrofw)
 	TARGET := $(TARGET_NAME)_libretro.so
 	CC = /opt/retrofw-toolchain/usr/bin/mipsel-linux-gcc
 	CXX = /opt/retrofw-toolchain/usr/bin/mipsel-linux-g++


### PR DESCRIPTION
Change `else ifneq (,$(findstring retrofw,$(platform)))` to `else ifeq ($(platform), retrofw)` its easier to read and will not break in future