### PR TITLE
Add .rom to the list of valid extensions

### DIFF
--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -632,7 +632,7 @@ void retro_get_system_info(struct retro_system_info* info)
     memset(info, 0, sizeof(*info));
     info->library_name = "Atari800";
     info->library_version = "3.1.0" GIT_VERSION;
-    info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|com|xex";
+    info->valid_extensions = "xfd|atr|cdm|cas|bin|a52|zip|atx|car|rom|com|xex";
     info->need_fullpath = true;
     info->block_extract = false;
 


### PR DESCRIPTION
Sometimes .rom is used interchangeably with .car