### PR TITLE
Fix type to enable compilation

### DIFF
--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -26,7 +26,7 @@ unsigned long  Ktime=0 , LastFPSTime=0;
 #endif 
 
 //SOUND
-short signed int SNDBUF[1024*2];
+unsigned char SNDBUF[1024*2*2];
 int snd_sampler_pal = 44100 / 50;
 int snd_sampler_ntsc = 44100 / 60;
 

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -135,7 +135,7 @@ extern int ToggleTV;
 extern int CURRENT_TV;
 
 extern int SHIFTON, pauseg, SND;
-extern short signed int SNDBUF[1024 * 2];
+extern unsigned char SNDBUF[];
 
 char RPATH[512];
 char RETRO_DIR[512];


### PR DESCRIPTION
Before this commit I got a compilation error about type mismatch between short int * and unsigned char *.

To keep the buffer size intact, I double the number of elements since char is usually half the size of short int.