### PR TITLE
Cast SNDBUF to UBYTE on callback to fix gcc-14.1 compile

### DIFF
--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -155,7 +155,7 @@ void retro_sound_update(void)
 
    if (! UI_is_active)
    {
-      Sound_Callback(SNDBUF, 1024*2*2);
+      Sound_Callback((UBYTE *)SNDBUF, 1024*2*2);
       for(x=0;x<stop*2;x+=2)
          retro_audio_cb(SNDBUF[x],SNDBUF[x+2]);
 


### PR DESCRIPTION
Fixes gcc-14,1 error

libretro/core-mapper.c: In function 'retro_sound_update': libretro/core-mapper.c:158:22: error: passing argument 1 of 'Sound_Callback' from incompatible pointer type [-Wincompatible-pointer-types]
  158 |       Sound_Callback(SNDBUF, 1024*2*2);
      |                      ^~~~~~
      |                      |
      |                      short int *
In file included from ./atari800/src/platform.h:11,
                 from libretro/core-mapper.c:4:
./atari800/src/sound.h:75:28: note: expected 'unsigned char *' but argument is of type 'short int *'
   75 | void Sound_Callback(UBYTE *buffer, unsigned int size);