### PR TITLE
Add Joy 2B+ support

### DIFF
--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -538,6 +538,17 @@ int Retro_PollEvent()
        else if (al[0][0] >= JOYRANGE_RIGHT_VALUE)
            MXjoy[1] |= 0x08;
    }
+   else if (atari_joyhack == 3 && !paddle_mode) //hack for supporting Joy 2B+ games
+   {
+      //use paddles' potentiometers for fire 2 and fire 3
+      POKEY_POT_input[0] = (joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_A)) ? INPUT_mouse_pot_max : INPUT_mouse_pot_min;
+      POKEY_POT_input[1] = (joypad_bits[0] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)) ? INPUT_mouse_pot_max : INPUT_mouse_pot_min;
+      POKEY_POT_input[2] = (joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_A)) ? INPUT_mouse_pot_max : INPUT_mouse_pot_min;
+      POKEY_POT_input[3] = (joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_Y)) ? INPUT_mouse_pot_max : INPUT_mouse_pot_min;
+      //prevent propagation of RETRO_DEVICE_ID_JOYPAD_Y that is interpreted as space key
+      joypad_bits[0] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_Y);
+      joypad_bits[1] &= ~(1 << RETRO_DEVICE_ID_JOYPAD_Y);
+   }
 
    if ( atari_devices[0] != RETRO_DEVICE_ATARI_KEYBOARD)
    {

--- a/libretro/libretro-core.c
+++ b/libretro/libretro-core.c
@@ -48,7 +48,7 @@ int retroh = 300;
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right" },            \
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B, "Fire 1" },               \
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A, "Fire 2" },               \
-       { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Space" },                 \
+       { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y, "Space/Fire 3" },                 \
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X, "Return" },               \
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },          \
        { _user, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },            \
@@ -538,7 +538,7 @@ static void update_variables(void)
             autorunCartridge = 0;
     }
 
-    /* Controller Hack for Dual Stick or Swap Ports*/
+    /* Controller Hack for Dual Stick, Swap Ports or Joy 2B+*/
     var.key = "atari800_opt2";
     var.value = NULL;
 
@@ -549,6 +549,8 @@ static void update_variables(void)
             atari_joyhack = 1;
         else if ( strcmp(var.value,"Swap Ports") == 0)
             atari_joyhack = 2;
+        else if ( strcmp(var.value,"Joy 2B+") == 0)
+            atari_joyhack = 3;
         else
             atari_joyhack = 0;
     }

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -60,7 +60,7 @@ struct retro_core_option_v2_category option_cats_us[] = {
    {
       "input",
       "Input",
-      "Configure 5200 Digital and Analog Joystick sensitivity and Analog deadzone.  Activate Swap or Dual Joysticks.  Activate Paddle mode and set Paddle speed.  Set retroarch keyboard type."
+      "Configure 5200 Digital and Analog Joystick sensitivity and Analog deadzone.  Activate Swap, Dual Joysticks or Joy 2B+. Activate Paddle mode and set Paddle speed.  Set retroarch keyboard type."
    },
    { NULL, NULL, NULL },
 };
@@ -119,13 +119,14 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "atari800_opt2",
       "Controller Hacks",
       NULL,
-      "Apply gamepad input hacks required for specific games. 'Dual Stick' maps Player 2's joystick to the right analog stick of Player 1's RetroPad, enabling dual stick control in 'Robotron 2084' and 'Space Dungeon'. 'Swap Ports' maps Player 1 to port 2 and Player 2 to port 1 of the emulated console, correcting the swapped inputs of 'Wizard of Wor', 'Apple Panic' and a few other games",
+      "Apply gamepad input hacks required for specific games. 'Dual Stick' maps Player 2's joystick to the right analog stick of Player 1's RetroPad, enabling dual stick control in 'Robotron 2084' and 'Space Dungeon'. 'Swap Ports' maps Player 1 to port 2 and Player 2 to port 1 of the emulated console, correcting the swapped inputs of 'Wizard of Wor', 'Apple Panic' and a few other games. 'Joy 2B+' enables multibutton joysticks support.",
       NULL,
       "input",
       {
          { "none", NULL },
          { "enabled",  "Dual Stick" },
          { "Swap Ports",  "Swap Ports" },
+         { "Joy 2B+",  "Joy 2B+" },
          { NULL, NULL },
       },
       "none"


### PR DESCRIPTION
This commit adds 'Joy 2B+' support to the core.

Joy 2B+ (https://github.com/ascrnet/Joy2Bplus) is a de facto standard for adding two additional buttons to Atari 8-bit microcomputers.

As of today, at least 80 games have been modified to support this standard: https://github.com/ascrnet/Joy2Bplus/wiki/Games

- To enable Joy 2B+ support: Quick Menu / Core Options / Input / Controller Hacks = Joy 2B+
- To configure buttons: Quick Menu / Controls / Port 1|2 Controls - Fire1, Fire 2 and "Space/Fire 3"

