### PR TITLE
Adjust PAL timings

### DIFF
--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -28,8 +28,8 @@ unsigned long  Ktime=0 , LastFPSTime=0;
 
 //SOUND
 UBYTE SNDBUF[1024*2*2];
-int snd_sampler_pal = 883;    // 44100 / 50 = 882 
-int snd_sampler_ntsc = 736;   // 44100 / 60  = 735  
+int snd_sampler_pal = 885;    // (int)(ceil(44100 / 49.8607597))
+int snd_sampler_ntsc = 736;   // (int)(ceil(44100 / 59.9227437))
 
 //EMU FLAGS
 int NPAGE = -1, KCOL = 1, BKGCOLOR = 0;

--- a/libretro/core-mapper.c
+++ b/libretro/core-mapper.c
@@ -152,9 +152,7 @@ extern int CURRENT_TV;
 
 void retro_sound_update(void)
 {	
-   // 882 is 44100/50
-   // 736 is 44100/60
-   // int x,stop=CURRENT_TV==312?885:742;//FIXME: 882/735?
+
    int x,stop=CURRENT_TV==Atari800_TV_PAL ? snd_sampler_pal : snd_sampler_ntsc;
    if (! UI_is_active)
    {


### PR DESCRIPTION
Fix issue reported here: https://github.com/libretro/libretro-atari800/issues/118 by @EvoluZion3.

When Video Standard = PAL, the core freezes after ~68 seconds.

`Quick Menu -> Core Options -> Video -> Video Standard = PAL`

According to upstream emulator ( https://github.com/atari800/atari800/commit/b4bdceef5f574acacc32e978330b66bc0c113092 )

The correct values are calculated here: https://github.com/atari800/atari800/blob/cb2bc675e79aaafbeb3494f8b8cfb508c390339e/src/libatari800/sound.c#L53-L58

```
	double refresh_rate;
	double samples_per_video_frame;

	refresh_rate = Atari800_tv_mode == Atari800_TV_PAL ? Atari800_FPS_PAL : Atari800_FPS_NTSC;
	samples_per_video_frame = setup->freq / refresh_rate;
	setup->buffer_frames = (int)(ceil(samples_per_video_frame));
```

So, the core now uses these values:

```
PAL: (int)(ceil(44100 / 49.8607597)) = 885 (it was 883)
NTSC: (int)(ceil(44100 / 59.9227437)) = 736
```
