### PR TITLE
info: restore dual-database identity (Atari 5200 + 8-bit Family)

### DIFF
--- a/atari800_libretro.info
+++ b/atari800_libretro.info
@@ -1,5 +1,5 @@
 # Software Information
-display_name = "Atari - 5200 (Atari800)"
+display_name = "Atari - 400/800/600XL/800XL/130XE/5200 (Atari800)"
 authors = "Petr Stehlik"
 supported_extensions = "xfd|atr|dcm|cas|bin|a52|zip|atx|car|rom|com|xex|m3u"
 corename = "Atari800"
@@ -9,12 +9,12 @@ permissions = ""
 
 # Hardware Information
 manufacturer = "Atari"
-systemname = "Atari 5200"
+systemname = "Atari 8-bit Family"
 systemid = "atari_5200"
-database = "Atari - 5200"
 display_version = "5.2.0"
 
 # Libretro Features
+database = "Atari - 5200|Atari - 8-bit Family"
 supports_no_game = "true"
 savestate = "true"
 savestate_features = "null"


### PR DESCRIPTION
## Summary

`atari800_libretro.info` currently advertises this core as Atari 5200 only:

```
display_name = "Atari - 5200 (Atari800)"
systemname   = "Atari 5200"
database     = "Atari - 5200"
```

That is too narrow — the core also emulates the Atari 8-bit computer family (400/800/600XL/800XL/130XE/XEGS) and exposes the *Atari System* selector in core options. With the current values RetroArch's playlist scanner will not route "Atari - 8-bit Family" content to this core; it only matches the "Atari - 5200" database. The README and `description` field both already mention 5200 *and* 8-bit, but the metadata that frontends actually consume does not.

This PR broadens the metadata back to the same shape libretro-super's distribution copy carries (and that's used by other multi-database cores like bsnes with `SNES|Sufami Turbo|Satellaview`), using the `Atari - 8-bit Family` database name that libretro-super adopted in [commit 227eec0e](https://github.com/libretro/libretro-super/commit/227eec0e86ec40a4a2edbedd6f11b663fcf6a784) (Rob Loach, 2025-08-14):

```
display_name = "Atari - 400/800/600XL/800XL/130XE/5200 (Atari800)"
systemname   = "Atari 8-bit Family"
database     = "Atari - 5200|Atari - 8-bit Family"
```

`database` is also moved from the *Hardware Information* block to *Libretro Features*, matching libretro-super's layout so the two files stay diff-clean. `systemid`, `display_version`, all firmware blocks, and `notes` are unchanged.

A companion PR for libretro-super (sync `display_version` 3.1.0 → 5.2.0 and the `ATARIOSB.ROM` md5) will follow once this lands.
