### PR TITLE
Fix console/MinGW builds: don't claim sys/ioctl.h in static config

### DIFF
--- a/libretro/config.h
+++ b/libretro/config.h
@@ -256,8 +256,12 @@
    */
 /* #undef HAVE_SYS_DIR_H */
 
-/* Define to 1 if you have the <sys/ioctl.h> header file. */
-#define HAVE_SYS_IOCTL_H 1
+/* Define to 1 if you have the <sys/ioctl.h> header file. This static config
+   is shared by every libretro target, and MinGW, Vita (newlib) and the
+   devkitPPC consoles have no <sys/ioctl.h> — monitor.c includes it whenever
+   this is defined (only for terminal-size detection, which no libretro build
+   uses), so it must stay undefined here. */
+/* #undef HAVE_SYS_IOCTL_H */
 
 /* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
    */


### PR DESCRIPTION
Follow-up to #134: the 7.0.0 sources widened monitor.c's include guard so `<sys/ioctl.h>` is pulled in whenever `HAVE_SYS_IOCTL_H` is defined (previously only for `GWINSZ_IN_SYS_IOCTL`). The libretro port's static `libretro/config.h` defined `HAVE_SYS_IOCTL_H` unconditionally for every platform, which broke the windows-x64/i686 (MinGW), vita (newlib) and wii/wiiu/ngc (devkitPPC) CI jobs — none of those toolchains ship `<sys/ioctl.h>`:

```
atari800/src/monitor.c:39:11: fatal error: sys/ioctl.h: No such file or directory
```

(Pipeline 89545 on git.libretro.com; the remaining 19 targets passed.)

The only consumer of the header is monitor.c's terminal-size detection (`TIOCGWINSZ`), which no libretro build exercises, so this undefines it for all targets instead of patching the vanilla upstream sources. Linux build verified locally with the change.