### PR TITLE
Atari 800: fix START/SELECT/OPTION being swallowed by held Atari keys

### DIFF
--- a/libretro/platform.c
+++ b/libretro/platform.c
@@ -243,6 +243,27 @@ int PLATFORM_Keyboard(void)
 	if (Key_State[RETROK_F4])
 		INPUT_key_consol &= (~INPUT_CONSOL_START);
 
+	/* The same console keys from the controller. This has to happen here,
+	   before the key scanning below, because that code returns an AKEY_* as
+	   soon as any Atari key is held -- and the frontend's default keyboard
+	   binds put several RetroPad buttons on keys the Atari also has (Enter
+	   is both "Start" and Return). Handling the console keys further down,
+	   next to the joypad AKEY_* binds, meant a held Return short-circuited
+	   the function and START/SELECT/OPTION never reached the machine. */
+	if (!UI_is_active && SHOWKEY == -1)
+	{
+		int port;
+		for (port = 0; port < 4; port++)
+		{
+			if (mbt[port][RETRO_DEVICE_ID_JOYPAD_SELECT])
+				INPUT_key_consol &= (~INPUT_CONSOL_SELECT);
+			if (mbt[port][RETRO_DEVICE_ID_JOYPAD_START])
+				INPUT_key_consol &= (~INPUT_CONSOL_START);
+			if (mbt[port][RETRO_DEVICE_ID_JOYPAD_L])
+				INPUT_key_consol &= (~INPUT_CONSOL_OPTION);
+		}
+	}
+
 	/* Handle movement and special keys. The built-in atari800 UI (legacy
 	 * F1/F10 menu) is not compiled into the libretro build, so no key is
 	 * mapped to AKEY_UI. */
@@ -655,12 +676,8 @@ int PLATFORM_Keyboard(void)
 		{
 			if (SHOWKEY == -1)
 			{
-				if (mbt[i][RETRO_DEVICE_ID_JOYPAD_SELECT])
-					INPUT_key_consol &= (~INPUT_CONSOL_SELECT);
-				if (mbt[i][RETRO_DEVICE_ID_JOYPAD_START])
-					INPUT_key_consol &= (~INPUT_CONSOL_START);
-				if (mbt[i][RETRO_DEVICE_ID_JOYPAD_L])
-					INPUT_key_consol &= (~INPUT_CONSOL_OPTION);
+				/* SELECT/START/OPTION are handled at the top of this
+				   function, before the key scanning can return early. */
 				/* R used to return AKEY_UI here to open the built-in atari800
 				   menu. That menu is disabled in the libretro build (see the
 				   comment in PLATFORM_Keyboard()), so the key was inert; it is


### PR DESCRIPTION
### The bug

The console keys are unusable from a keyboard with the frontend's default binds: pressing Enter (RetroPad Start) does nothing, so games that wait for START simply never start. The same applies to any RetroPad button whose keyboard bind is also a key the Atari has.

`PLATFORM_Keyboard()` does this, in order:

1. `libretro/platform.c:238` — resets `INPUT_key_consol` and sets it from F2/F3/F4,
2. scans the keyboard and returns an `AKEY_*` as soon as a mapped key is held — e.g. `platform.c:410`, `if (Key_State[RETROK_RETURN]) return AKEY_RETURN;`,
3. only at the end of the function turns the controller's Start/Select/Option into console keys.

In the default `atari800_keyboard = "poll"` mode the core polls the whole keyboard itself, so pressing Enter delivers *both* the RetroPad Start bit and `RETROK_RETURN`. Step 2 then returns before step 3 ever runs and the START bit is dropped; the machine only receives a Return keypress.

Confirmed on a live RetroArch session with a debug build logging what the core actually receives:

```
[DBG] joypad_bits[0]=0x0008     <- RetroPad Start
[DBG] keyboard key=13           <- RETROK_RETURN, same keypress
```

### The fix

Move the `mbt[] -> INPUT_key_consol` mapping up next to the existing F2/F3/F4 handling, before the key scanning can return early. The joypad `AKEY_*` binds (Y/X/L2/R2) stay where they are — those are returns, not console bits, so their ordering relative to the keyboard is unchanged. The `!UI_is_active` and `SHOWKEY == -1` guards are preserved.

### Testing

dlopen harness on Berzerk (.atr), pressing the given inputs on the title screen and hashing the framebuffer 240 frames later:

| input | before | after |
|---|---|---|
| RetroPad Start + `RETROK_RETURN` (what Enter sends) | title screen, unchanged | game starts |
| `RETROK_RETURN` alone | unchanged | unchanged |
| RetroPad Start alone | game starts | game starts |
| F4 | game starts | game starts |

Also verified in RetroArch on a real session: Enter now starts the game.